### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,8 @@
 # supported CodeQL languages.
 #
 name: "CodeQL"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nathanlytang/Steve/security/code-scanning/1](https://github.com/nathanlytang/Steve/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default. The best minimal, non-breaking fix is to add it at the workflow root (applies to all jobs unless overridden), directly under `name` and before `on`, with:

- `contents: read`

This matches the CodeQL recommendation and preserves existing behavior for this workflow (checkout + CodeQL analysis) while explicitly enforcing least privilege.

**File to change:**
- `.github/workflows/codeql-analysis.yml`  
Add the `permissions` block near the top-level keys (after `name:` is the clearest placement).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
